### PR TITLE
Make webconsole start by default

### DIFF
--- a/webconsole/src/main/java/org/secondbase/webconsole/HttpWebConsole.java
+++ b/webconsole/src/main/java/org/secondbase/webconsole/HttpWebConsole.java
@@ -84,7 +84,7 @@ public final class HttpWebConsole implements SecondBaseModule, WebConsole {
 
     @Override
     public void shutdown() throws IOException {
-        if (! WebConsoleConfiguration.enableWebConsole) {
+        if (WebConsoleConfiguration.port == 0) {
             return;
         }
         LOG.info("Shutting down webconsole.");

--- a/webconsole/src/main/java/org/secondbase/webconsole/WebConsoleConfiguration.java
+++ b/webconsole/src/main/java/org/secondbase/webconsole/WebConsoleConfiguration.java
@@ -6,10 +6,6 @@ import org.secondbase.flags.Flag;
  * Configuration parameters for the WebConsole.
  */
 public final class WebConsoleConfiguration {
-
-    @Flag(name = "enable-webconsole", description = "Start the web console")
-    public static boolean enableWebConsole = false;
-
     @Flag(
             name = "webconsole-port",
             description = "The port used by the webconsole (default 0 will select an available " +


### PR DESCRIPTION
- If webconsole is in classpath, the webconsole should start.
- Webconsole should not start if port is set to 0.