### PR TITLE
Change property for deploy profile activation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,5 +48,5 @@ jobs:
             echo $GPG_KEY | base64 --decode > signing-key
             gpg --pinentry-mode loopback --passphrase $GPG_PASSPHRASE --import signing-key
             shred signing-key
-            mvn -s .circleci/settings.xml -DskipTests -DperformRelease deploy
+            mvn -s .circleci/settings.xml -DskipTests -release deploy
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,5 +48,5 @@ jobs:
             echo $GPG_KEY | base64 --decode > signing-key
             gpg --pinentry-mode loopback --passphrase $GPG_PASSPHRASE --import signing-key
             shred signing-key
-            mvn -s .circleci/settings.xml -DskipTests -release deploy
+            mvn -s .circleci/settings.xml -DskipTests -Drelease deploy
           fi

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
             <id>ossrh</id>
             <activation>
                 <property>
-                    <name>performRelease</name>
+                    <name>release</name>
                     <value>true</value>
                 </property>
             </activation>


### PR DESCRIPTION
* Using "performRelease" also triggers gpg signing during
"mvn release". Signing is not set up for a regular developer,
so we'll need to use another key. Using "release", since it's
not treated specially.