### PR TITLE
Remove dependency on Joda Time

### DIFF
--- a/jsonlogging/pom.xml
+++ b/jsonlogging/pom.xml
@@ -14,7 +14,6 @@
     <name>jsonlogging</name>
 
     <properties>
-        <joda-time.version>2.3</joda-time.version>
         <logback.version>1.2.3</logback.version>
         <logstash-logback-encoder.version>4.9</logstash-logback-encoder.version>
         <hamcrest.version>2.0.0.0</hamcrest.version>
@@ -71,11 +70,6 @@
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
             <version>${logstash-logback-encoder.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>${joda-time.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/jsonlogging/src/main/java/com/github/secondbase/logging/SecondBaseLogger.java
+++ b/jsonlogging/src/main/java/com/github/secondbase/logging/SecondBaseLogger.java
@@ -21,7 +21,6 @@ import net.logstash.logback.composite.loggingevent.MdcJsonProvider;
 import net.logstash.logback.composite.loggingevent.MessageJsonProvider;
 import net.logstash.logback.composite.loggingevent.StackTraceJsonProvider;
 import net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder;
-import org.joda.time.DateTimeZone;
 import org.slf4j.LoggerFactory;
 
 public final class SecondBaseLogger {
@@ -177,7 +176,7 @@ public final class SecondBaseLogger {
         if (serviceLog) {
             final LoggingEventFormattedTimestampJsonProvider timeStampProvider
                     = new LoggingEventFormattedTimestampJsonProvider();
-            timeStampProvider.setTimeZone(DateTimeZone.UTC.getID());
+            timeStampProvider.setTimeZone("UTC");
             timeStampProvider.setFieldName("timestamp");
             jsonProviders.addTimestamp(timeStampProvider);
             customFieldsJsonProvider.setCustomFields("{\"type\":\"servicelog\"}");

--- a/jsonlogging/src/test/java/com/github/secondbase/logging/SecondBaseLoggerTest.java
+++ b/jsonlogging/src/test/java/com/github/secondbase/logging/SecondBaseLoggerTest.java
@@ -1,5 +1,12 @@
 package com.github.secondbase.logging;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -17,12 +24,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -119,7 +120,7 @@ public class SecondBaseLoggerTest {
         assertThat(node.get("datacenter").asText(), is("datacenter"));
         assertThat(node.get("service").asText(), is("service"));
         assertThat(node.get("level").asText(), is("INFO"));
-        assertThat(node.has("timestamp"), is(true));
+        assertThat(node.get("timestamp").asText(), endsWith("+00:00"));
         assertThat(node.get("type").asText(), is("servicelog"));
         encoder.stop();
         outputStream.close();


### PR DESCRIPTION
Joda Time library is deprecated and replaced by javax.time in Java 8.